### PR TITLE
Iam error handling

### DIFF
--- a/deployment/__tests__/test_assign_iam.py
+++ b/deployment/__tests__/test_assign_iam.py
@@ -83,3 +83,10 @@ def test_attach_custom_policy_adds_the_policy_to_the_appropriate_role():
     assert result['ResponseMetadata']['HTTPStatusCode'] == 200
     result = permissions.iam.list_attached_role_policies(RoleName='test-role')
     assert 's3-read-test-bucket-test-lambda' in [policy['PolicyName'] for policy in result['AttachedPolicies']]
+
+@mock_iam
+def test_if_a_policy_exists_get_policy_information_and_return_in_same_format():
+    permissions = Assign_iam()
+    initial = permissions.create_s3_read_write_policy("test-lambda","test-bucket")
+    result = permissions.create_s3_read_write_policy("test-lambda","test-bucket")
+    assert initial['Policy']['Arn'] == result['Policy']['Arn']

--- a/deployment/__tests__/test_assign_iam.py
+++ b/deployment/__tests__/test_assign_iam.py
@@ -98,3 +98,10 @@ def test_if_a_cloudwatch_policy_exists_get_policy_information_and_return_in_same
     initial = permissions.create_cloudwatch_logging_policy("test-lambda")
     result = permissions.create_cloudwatch_logging_policy("test-lambda")
     assert initial['Policy']['Arn'] == result['Policy']['Arn']
+
+@mock_iam
+def test_if_a_role_exists_get_role_information_and_return_in_same_format():
+    permissions = Assign_iam()
+    initial = permissions.create_lambda_role(role_name='test-role')
+    result = permissions.create_lambda_role(role_name='test-role')
+    assert initial['Role']['Arn'] == result['Role']['Arn']

--- a/deployment/__tests__/test_assign_iam.py
+++ b/deployment/__tests__/test_assign_iam.py
@@ -90,3 +90,11 @@ def test_if_a_policy_exists_get_policy_information_and_return_in_same_format():
     initial = permissions.create_s3_read_write_policy("test-lambda","test-bucket")
     result = permissions.create_s3_read_write_policy("test-lambda","test-bucket")
     assert initial['Policy']['Arn'] == result['Policy']['Arn']
+
+
+@mock_iam
+def test_if_a_cloudwatch_policy_exists_get_policy_information_and_return_in_same_format():
+    permissions = Assign_iam()
+    initial = permissions.create_cloudwatch_logging_policy("test-lambda")
+    result = permissions.create_cloudwatch_logging_policy("test-lambda")
+    assert initial['Policy']['Arn'] == result['Policy']['Arn']

--- a/deployment/src/assign_iam.py
+++ b/deployment/src/assign_iam.py
@@ -30,10 +30,16 @@ class Assign_iam():
     def create_lambda_role(self,role_name:str):
         """Sets up role of passed name, with the ability of a lambda function to assume said role, and saves the arn on a key of the name in roles"""
         lambda_role_document = '{"Version": "2012-10-17","Statement": [{ "Effect": "Allow", "Principal": {"Service": "lambda.amazonaws.com"},"Action": "sts:AssumeRole"}]}'
-        response = self.iam.create_role(
-            RoleName=role_name,
-            AssumeRolePolicyDocument = lambda_role_document
-        )
+        try:
+            response = self.iam.create_role(
+                RoleName=role_name,
+                AssumeRolePolicyDocument = lambda_role_document
+            )
+        except ClientError as ce:
+            if ce.response['Error']['Code'] == 'EntityAlreadyExistsException':
+                print(f'{role_name} role already exists, reading from iam')
+                responses = self.iam.list_roles()
+                response = {'Role':role for role in responses['Roles']}
         self.role_arns[role_name] = response['Role']['Arn']
         return response
     
@@ -56,25 +62,40 @@ class Assign_iam():
             PolicyArn='arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
         )
         return response
+    
     def create_cloudwatch_logging_policy(self, lambda_name:str):
         """Creates a cloudwatch policy for having access to the lambda's logger, and saves the arn on a key of the name in policies"""
-        response = self.iam.create_policy(
-            PolicyName=f'cloudwatch-policy-{lambda_name}',
-            PolicyDocument=create_cloudwatch_policy_json(lambda_name),
-            Description=f'Cloudwatch policy for {lambda_name}'
-        )
+        policy_name = f'cloudwatch-policy-{lambda_name}'
+        try:
+            response = self.iam.create_policy(
+                PolicyName=policy_name,
+                PolicyDocument=create_cloudwatch_policy_json(lambda_name),
+                Description=f'Cloudwatch policy for {lambda_name}'
+            )
+        except ClientError as ce:
+            if ce.response['Error']['Code'] == 'EntityAlreadyExistsException':
+                print(f'{policy_name} policy already exists, reading from iam')
+                responses = self.iam.list_policies(Scope='ALL')
+                response = {'Policy':policy for policy in responses['Policies']}
+            
         self.policy_arns[f'cloudwatch-policy-{lambda_name}'] = response['Policy']['Arn']
         return response
     
     def create_s3_read_write_policy(self, lambda_name:str, bucket:str,read:bool=True,write:bool=False):
         """Creates a policy for reading, and/or writing from the given bucket, and saves the arn on a key of the name in policies"""
         name_modifier = "read" if not write else "read-write"
-            
-        response = self.iam.create_policy(
-            PolicyName=f's3-{name_modifier}-{bucket}-{lambda_name}',
-            PolicyDocument=create_s3_access_policy_json(bucket,list=read, get=read,put=write),
-            Description=f'Read the ingest bucket policy policy for {lambda_name}'
-        )
+        policy_name = f's3-{name_modifier}-{bucket}-{lambda_name}'
+        try:
+            response = self.iam.create_policy(
+                PolicyName=policy_name,
+                PolicyDocument=create_s3_access_policy_json(bucket,list=read, get=read,put=write),
+                Description=f'Read the ingest bucket policy policy for {lambda_name}'
+            )
+        except ClientError as ce:
+            if ce.response['Error']['Code'] == 'EntityAlreadyExistsException':
+                print(f'{policy_name} policy already exists, reading from iam')
+                responses = self.iam.list_policies(Scope='ALL')
+                response = {'Policy':policy for policy in responses['Policies']}
         self.policy_arns[f's3-{name_modifier}-{bucket}-{lambda_name}'] = response['Policy']['Arn']
         return response
     

--- a/deployment/src/assign_iam.py
+++ b/deployment/src/assign_iam.py
@@ -37,7 +37,7 @@ class Assign_iam():
                 AssumeRolePolicyDocument = lambda_role_document
             )
         except ClientError as ce:
-            if ce.response['Error']['Code'] == 'EntityAlreadyExistsException':
+            if ce.response['Error']['Code'] == 'EntityAlreadyExists':
                 print(f'{role_name} role already exists, reading from iam')
                 responses = self.iam.list_roles()
                 response = {'Role':role for role in responses['Roles']}
@@ -75,7 +75,7 @@ class Assign_iam():
                 Description=f'Cloudwatch policy for {lambda_name}'
             )
         except ClientError as ce:
-            if ce.response['Error']['Code'] == 'EntityAlreadyExistsException':
+            if ce.response['Error']['Code'] == 'EntityAlreadyExists':
                 print(f'{policy_name} policy already exists, reading from iam')
                 responses = self.iam.list_policies(Scope='Local')
                 response = {'Policy':policy for policy in responses['Policies'] if policy['PolicyName'] == policy_name}


### PR DESCRIPTION
Handle client errors of pre-existing names for roles and policies causes a list call to be made in order to return the correct policy or role in the correct form